### PR TITLE
WP: Architecture Stack follow up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "architecturestack",
-	"version": "3.1.3",
+	"version": "3.1.4",
 	"description": "Shows a matrix that is formed based on the properties and/or tags of factsheets. Depending on the configuration, X and Y axes as well as the coloring are adjustable.",
 	"engines": {
 		"node": ">=8.12.0"
@@ -38,7 +38,7 @@
 		"tar": "3.1.5",
 		"url-loader": "0.5.9",
 		"webpack": "3.0.0",
-		"webpack-dev-server": "2.5.0"
+		"webpack-dev-server": "^2.5.0"
 	},
 	"dependencies": {
 		"@leanix/reporting": "0.2.5",

--- a/src/ConfigureDialog.js
+++ b/src/ConfigureDialog.js
@@ -12,11 +12,16 @@ class ConfigureDialog extends Component {
 	constructor(props) {
 		super(props);
 		this.configStore = null; // set during opening a configure dialog (see render)
+
 		// bindings
 		this._handleOnClose = this._handleOnClose.bind(this);
 		this._handleOnOK = this._handleOnOK.bind(this);
 		this._handleFactsheetTypeSelect = this._handleFactsheetTypeSelect.bind(this);
 		this._handleShowEmptyRowsCheck = this._handleShowEmptyRowsCheck.bind(this);
+
+		this._handleFieldsOnRelationsCheck = this._handleFieldsOnRelationsCheck.bind(this);
+		this._handleFieldsOnRelatedFactSheetsCheck = this._handleFieldsOnRelatedFactSheetsCheck.bind(this);
+
 		this._handleShowEmptyColumnsCheck = this._handleShowEmptyColumnsCheck.bind(this);
 		this._handleShowMissingDataWarningCheck = this._handleShowMissingDataWarningCheck.bind(this);
 		this._renderContent = this._renderContent.bind(this);
@@ -58,6 +63,16 @@ class ConfigureDialog extends Component {
 		}
 		this.configStore.showEmptyColumns = !val;
 		this.forceUpdate();
+	}
+
+	_handleFieldsOnRelationsCheck(val) {
+		this.configStore.showFieldsOnRelations = val
+		this.forceUpdate()
+	}
+
+	_handleFieldsOnRelatedFactSheetsCheck(val) {
+		this.configStore.showFieldsOnRelatedFactSheets = val
+		this.forceUpdate()
 	}
 
 	_handleShowMissingDataWarningCheck(val) {
@@ -108,6 +123,18 @@ class ConfigureDialog extends Component {
 					onChange={this._handleShowEmptyColumnsCheck}
 					hasError={errors.showEmptyColumns ? true : false}
 					helpText={errors.showEmptyColumns} />
+				<Checkbox id='showFieldsOnRelations' label='Show fields on relations'
+					useSmallerFontSize
+					value={this.configStore.showFieldsOnRelations}
+					onChange={this._handleFieldsOnRelationsCheck}
+					hasError={errors.showFieldsOnRelations ? true : false}
+					helpText={errors.showFieldsOnRelations} />
+				<Checkbox id='showFieldsOnRelatedFactSheets' label='Show fields on related Fact Sheets'
+					useSmallerFontSize
+					value={this.configStore.showFieldsOnRelatedFactSheets}
+					onChange={this._handleFieldsOnRelatedFactSheetsCheck}
+					hasError={errors.showFieldsOnRelatedFactSheets ? true : false}
+					helpText={errors.showFieldsOnRelatedFactSheets} />
 				<Checkbox id='showMissingDataWarning' label='Show missing data warning'
 					useSmallerFontSize
 					value={this.configStore.showMissingDataWarning}

--- a/src/Report.js
+++ b/src/Report.js
@@ -40,6 +40,8 @@ class Report extends Component {
 		this.reportState = new ReportState();
 		this.reportState.prepareBooleanValue('showEmptyRows', false);
 		this.reportState.prepareBooleanValue('showEmptyColumns', false);
+		this.reportState.prepareBooleanValue('showFieldsOnRelations', false);
+		this.reportState.prepareBooleanValue('showFieldsOnRelatedFactSheets', false);
 		this.reportState.prepareBooleanValue('showMissingDataWarning', true);
 		// bindings
 		this._initReport = this._initReport.bind(this);
@@ -566,6 +568,7 @@ class Report extends Component {
 	}
 
 	_renderSelectFields(factsheetType) {
+		const { showFieldsOnRelatedFactSheets, showFieldsOnRelations } = this.reportState.get()
 		let xAxisOption = undefined;
 		let yAxisOption = undefined;
 		let xAxisOptions = [];
@@ -573,7 +576,8 @@ class Report extends Component {
 		if (factsheetType) {
 			xAxisOption = this.reportState.get('selectedXAxis').key;
 			yAxisOption = this.reportState.get('selectedYAxis').key;
-			const models = this.axisModels[factsheetType];
+			const models = (this.axisModels[factsheetType] || [])
+				.filter(model => !(!showFieldsOnRelatedFactSheets && model.type == 'FIELD_TARGET_FS' || !showFieldsOnRelations && model.type === 'FIELD_RELATION'))
 			xAxisOptions = this._filterAndMapModelsToViewOptions(models, (model) => {
 				// remove selected y axis from x axis options
 				return model.key !== yAxisOption;


### PR DESCRIPTION
package.json version bumped to 3.1.4

Implements the following requirements:
A_2 Fields on relations and related fact sheets have to be toggleable in the settings modal
A_2.1 In settings modal: "Show fields on relations"
A_2.2 In settings modal: "Show fields on related Fact Sheets"

A_3 default of those settings is "off"

PS: as requested, A_1 was left off.